### PR TITLE
feat: adding apache openserverless java based runtimes

### DIFF
--- a/runtimes.json
+++ b/runtimes.json
@@ -20,7 +20,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-nodejs",
-                    "tag": "v21-2409121644"
+                    "tag": "v21-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -47,7 +47,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-nodejs",
-                    "tag": "v20-2409121644"
+                    "tag": "v20-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -61,7 +61,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-nodejs",
-                    "tag": "v18-2409121644"
+                    "tag": "v18-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -77,7 +77,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-python",
-                    "tag": "v3.12-2409121644"
+                    "tag": "v3.12-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -104,7 +104,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-python",
-                    "tag": "v3.11-2409121644"
+                    "tag": "v3.11-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -118,7 +118,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-python",
-                    "tag": "v3.12-2409121644"
+                    "tag": "v3.12-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -132,7 +132,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-python",
-                    "tag": "v3.11ca-2409121644"
+                    "tag": "v3.11ca-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -146,7 +146,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-python",
-                    "tag": "v3.10-2409121644"
+                    "tag": "v3.10-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -167,7 +167,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-go",
-                    "tag": "v1.22-2409121644"
+                    "tag": "v1.22-2409142109"
                 }
             },
             {
@@ -181,7 +181,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-go",
-                    "tag": "v1.21-2409121644"
+                    "tag": "v1.21-2409142109"
                 }
             },
             {
@@ -195,7 +195,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-go",
-                    "tag": "v1.20-2409121644"
+                    "tag": "v1.20-2409142109"
                 }
             },            
             {
@@ -218,9 +218,9 @@
                 "kind": "java:8",
                 "default": true,
                 "image": {
-                    "prefix": "ghcr.io/nuvolaris",
-                    "name": "action-java-v8",
-                    "tag": "0.3.0-morpheus.22110809"
+                    "prefix": "apache",
+                    "name": "openserverless-runtime-java",
+                    "tag": "v8-2409142109"
                 },
                 "deprecated": false,
                 "attached": {
@@ -228,7 +228,52 @@
                     "attachmentType": "text/plain"
                 },
                 "requireMain": true
-            }
+            },
+            {
+                "kind": "java:11",
+                "default": false,
+                "image": {
+                    "prefix": "apache",
+                    "name": "openserverless-runtime-java",
+                    "tag": "v11-2409142109"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "requireMain": true
+            },
+            {
+                "kind": "java:17",
+                "default": false,
+                "image": {
+                    "prefix": "apache",
+                    "name": "openserverless-runtime-java",
+                    "tag": "v17-2409142109"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "requireMain": true
+            },
+            {
+                "kind": "java:21",
+                "default": false,
+                "image": {
+                    "prefix": "apache",
+                    "name": "openserverless-runtime-java",
+                    "tag": "v21-2409142109"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "requireMain": true
+            }            
         ],
         "php": [
             {
@@ -238,7 +283,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-php",
-                    "tag": "v8.3-2409121644"
+                    "tag": "v8.3-2409142109"
                 },
                 "attached": {
                     "attachmentName": "codefile",
@@ -252,7 +297,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-php",
-                    "tag": "v8.2-2409121644"
+                    "tag": "v8.2-2409142109"
                 },
                 "attached": {
                     "attachmentName": "codefile",
@@ -266,7 +311,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-php",
-                    "tag": "v8.1-2409121644"
+                    "tag": "v8.1-2409142109"
                 },
                 "attached": {
                     "attachmentName": "codefile",
@@ -280,7 +325,7 @@
                 "image": {
                     "prefix": "apache",
                     "name": "openserverless-runtime-php",
-                    "tag": "v8.0-2409121644"
+                    "tag": "v8.0-2409142109"
                 },
                 "attached": {
                     "attachmentName": "codefile",


### PR DESCRIPTION
This PR deploys a new `runtimes.json` providing newer Apache OpenServerless java runtimes for version 8,11,17 and 21. V8 it is still set as the default one.