### PR TITLE
chore: auth in useradd doesn't use AUTH

### DIFF
--- a/admin/opsfile.yml
+++ b/admin/opsfile.yml
@@ -46,7 +46,7 @@ tasks:
         export USERNAME={{._username_}}
         export EMAIL={{._email_}}
         export PASSWORD={{._password_}} 
-        export AUTH="$($OPS -random -u):$($OPS -random --str 64)"
+        export SECRET_USER_AUTH="$($OPS -random -u):$($OPS -random --str 64)"
 
         # check {{._username_}} is at least 5 chars long
         if [ ${#USERNAME} -lt 5 ]

--- a/admin/user-crd.yaml
+++ b/admin/user-crd.yaml
@@ -25,7 +25,7 @@ spec:
   email: ${EMAIL}
   password: ${PASSWORD}
   namespace: ${USERNAME}
-  auth: ${AUTH}
+  auth: ${SECRET_USER_AUTH}
   redis:
     enabled: ${REDIS_ENABLED}
     prefix: ${USERNAME}


### PR DESCRIPTION
There was an overlap between the AUTH variable (set by ops -login) and the AUTH setup by ops admin adduser. Moved the last to SECRET_AUTH_USER