### PR TITLE
feat: allow digits in the configuration key names

### DIFF
--- a/util/config/configurator/configurator.ts
+++ b/util/config/configurator/configurator.ts
@@ -306,7 +306,7 @@ export function isInputConfigValid(body: Record<string, any>): boolean {
 
   // 3. Check that all the keys are uppercase and can only have underscores not at the beginning or end
   for (const key in body) {
-    if (!/^[A-Z][A-Z_]*[A-Z]$/.test(key)) {
+    if (!/^[A-Z][A-Z_]|[0-9]*[A-Z]|[0-9]$/.test(key)) {
       return false;
     }
   }

--- a/util/config/configurator/tests/fixtures/valid.json
+++ b/util/config/configurator/tests/fixtures/valid.json
@@ -1,5 +1,11 @@
 {
   "HELLO": {
     "type": "string"
+  },
+  "HELLO3": {
+    "type": "string"
+  },
+  "HELLO_3": {
+    "type": "string"
   }
 }

--- a/util/config/configurator/tests/index.test.ts
+++ b/util/config/configurator/tests/index.test.ts
@@ -56,11 +56,18 @@ describe("validateConfigJson", () => {
   test("valid json", async () => {
     const res = isInputConfigValid({
       HELLO: { type: "string" },
+      HELLO3: { type: "string" },
+      HELLO33: { type: "string" },
+      HELLO_3: { type: "string" },
+      HELLO_33: { type: "string" },
+      HELLO_A_1_B_2: { type: "string" },
+      HELLO_A1B2: { type: "string" },
       HELLO_INT: { type: "int" },
       HELLO_FLOAT: { type: "float" },
       HELLO_BOOL: { type: "bool" },
       HELLOPASS: { type: "password" },
       HELLOENUM: { type: ["a", "b", "c"] },
+      HELLOENUM3: { type: ["a", "b", "c"] },
     });
     expect(res).toBe(true);
   });
@@ -109,6 +116,8 @@ describe("parsePositionalFile", () => {
   test("valid json", async () => {
     const jsonRes = await parsePositionalFile("tests//fixtures/valid.json");
     expect(jsonRes.success).toBe(true);
-    expect(jsonRes.body).toEqual({ HELLO: { type: "string" } });
+    expect(jsonRes.body).toHaveProperty("HELLO", { type: "string" }  );
+    expect(jsonRes.body).toHaveProperty("HELLO3", { type: "string" } );
+    expect(jsonRes.body).toHaveProperty("HELLO_3", { type: "string" });
   });
 });


### PR DESCRIPTION
This allows digits in a non leading position.
For example, the names HELLO3 and HELLO_A_B_C3 are now allowed.
Closes https://github.com/apache/openserverless/issues/69