### PR TITLE
chore: operator storage class

### DIFF
--- a/setup/kubernetes/opsfile.yml
+++ b/setup/kubernetes/opsfile.yml
@@ -75,7 +75,7 @@ env:
 
   OPERATOR_VOLUME_STORAGE_CLASS:
     sh: |
-      echo $(kubectl get storageclass -ojsonpath="{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=='true')].metadata.name}")    
+      echo $(kubectl --kubeconfig $OPS_TMP/kubeconfig get storageclass -ojsonpath="{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=='true')].metadata.name}")    
 
 tasks:
   status:


### PR DESCRIPTION
OPERATOR_VOLUME_STORAGE_CLASS require to read the current ops configured kubeconfig. Added a temporary fix. Need a better solution