### PR TITLE
fix: ignore tmpN files

### DIFF
--- a/ide/deploy/client.js
+++ b/ide/deploy/client.js
@@ -21,6 +21,13 @@ import { resolve } from 'path';
 import process from 'process';
 import { createInterface } from 'readline';
 
+/**
+ * Read a key from OpenServerless configuration added to a `package.json` file in the
+ * root of the project
+ * @param key the key to read
+ * @param defaultValue a default value to be returned when the key is not found
+ * @returns {*}
+ */
 export function getOpenServerlessConfig(key, defaultValue) {
   try {
     const dir = process.env.OPS_PWD || '/do_not_exists';
@@ -32,6 +39,12 @@ export function getOpenServerlessConfig(key, defaultValue) {
   }
 }
 
+/**
+ * This function creates a line-by-line interface over the provided input stream
+ * and logs each line to the console as it is received.
+ * @param {ReadableStream} inp - The input stream to read lines from.
+ * @returns {void}
+ */
 function readlines(inp) {
   const rl = createInterface({ input: inp, terminal: false });
   rl.on('line', (line) => {
@@ -39,6 +52,12 @@ function readlines(inp) {
   });
 }
 
+/**
+ * laungh a process with the command taken from OpenServerless Config
+ * (see `getOpenServerlessConfig`)
+ * @param key
+ * @param defaultValue
+ */
 export function launch(key, defaultValue) {
   const cmd = getOpenServerlessConfig(key, defaultValue);
   const proc = spawn(cmd, {
@@ -52,14 +71,26 @@ export function launch(key, defaultValue) {
   readlines(proc.stderr);
 }
 
+/**
+ * start `ops ide serve` or a custom devel function specified
+ * through `getOpenServerlessConfig` mechanism
+ */
 export function serve() {
   launch('devel', 'ops ide serve');
 }
 
+/**
+ * start `ops activation poll` or a custom logs function
+ * through `getOpenServerlessConfig` mechanism
+ */
 export function logs() {
   launch('logs', 'ops activation poll');
 }
 
+/**
+ * start a custom deploy function if required from the user
+ * through `getOpenServerlessConfig` mechanism
+ */
 export function build() {
   const deploy = getOpenServerlessConfig('deploy', 'true');
   const proc = spawn(deploy, {

--- a/ide/deploy/deploy.js
+++ b/ide/deploy/deploy.js
@@ -119,13 +119,16 @@ export function deployAction(artifact) {
 
   if (queue.length > 0) {
     const nextArtifact = queue.shift();
-    console.debug(`deployding from queue artifact ${nextArtifact}`);
+    console.debug(`deploying from queue artifact ${nextArtifact}`);
     deploy(nextArtifact);
   }
 }
 
 
-
+/**
+ * Deploy a `file`
+ * @param file
+ */
 export function deploy(file) {
   // Uncomment the lines below to test specific files
   // const file = "packages/deploy/hello.py";

--- a/ide/deploy/serve.js
+++ b/ide/deploy/serve.js
@@ -20,7 +20,12 @@ import {resolve, extname} from "path";
 import {parse} from "url";
 import process from 'process';
 
-// Helper function to find the first available port starting from 8080
+/**
+ * Helper function to find the first available port starting from 8080
+ * @param host
+ * @param startPort
+ * @returns {Promise<number>}
+ */
 async function findAvailablePort(host, startPort = 8080) {
     host = host || '127.0.0.1';
     for (let port = startPort; port < 65535; port++) {
@@ -42,6 +47,11 @@ async function findAvailablePort(host, startPort = 8080) {
     throw new Error("No available port found.");
 }
 
+/**
+ * Helper function thath convert the input stream to a Buffer
+ * @param stream
+ * @returns {Promise<Buffer<ArrayBuffer>>}
+ */
 async function toBuffer(stream) {
     const list = []
     const reader = stream.getReader();
@@ -55,7 +65,12 @@ async function toBuffer(stream) {
     return Buffer.concat(list)
 }
 
-// Helper function to determine MIME type based on file extension
+//
+/**
+ * Helper function to determine MIME type based on file extension
+ * @param filePath
+ * @returns {*|string}
+ */
 function getMimeType(filePath) {
     const ext = extname(filePath).toLowerCase();
     const mimeTypes = {
@@ -75,6 +90,14 @@ function getMimeType(filePath) {
 
 const excludedAssets = ['favicon.ico'];
 
+/**
+ * Entry point. This will start a web server on the first available port
+ * starting from 8080. When the file ot serve is not local and a proxy host
+ * is specified by the `-P flag`, the request will be sent to the proxy host
+ * and the response returned back.
+ *
+ * @returns {Promise<Response>}
+ */
 async function main() {
 
     // Get command-line arguments
@@ -164,11 +187,11 @@ async function main() {
                         method: req.method,
                         headers: newHeaders,
                     };
-                    if (req.method.toLowerCase() != 'get') {
+                    if (req.method.toLowerCase() !== 'get') {
                         let body = await toBuffer(req.body);
                         body = body.toString('utf8');
 
-                        if (body != undefined) {
+                        if (body !== undefined) {
                             init['body'] = body;
                         }
                     }


### PR DESCRIPTION
added a shouldIgnoreFile function that is used to exclude files from watcher and deploy. Improved code comments on each function