### PR TITLE
chore: aligned default index.html to same content as the operator

### DIFF
--- a/util/upload/assets/index.html
+++ b/util/upload/assets/index.html
@@ -22,11 +22,11 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title>Nuvolaris Static Content landing page</title>    
+    <title>Apache OpenServerless (incubating) Static Content landing page</title>    
 </head>
 <body>
     <p>
-        Welcome to Nuvolaris static content distributor landing page!!!
+        Welcome to Apache OpenServerless (incubating) static content distributor landing page!!!
     </p>
 </body>
 </html>


### PR DESCRIPTION
aligned default index.html to same content as the operator. Future version  could eventually deploy better templates.