### PR TITLE
Implement project 

### DIFF
--- a/ide/deploy/deploy.js
+++ b/ide/deploy/deploy.js
@@ -163,7 +163,7 @@ export function deployProject(artifact) {
     if (manifestContent.indexOf('packages:')!==-1) {
       exec(`$OPS -wsk project deploy --manifest ${artifact}`);
     } else {
-      console.log(`Wanring: it seems that the ${artifact} file is not a valid manifest file. Skipping`);
+      console.log(`Warning: it seems that the ${artifact} file is not a valid manifest file. Skipping`);
     }
   }
 }

--- a/ide/deploy/scan.js
+++ b/ide/deploy/scan.js
@@ -158,9 +158,9 @@ export async function scan() {
         manifests.sort((a, b) => a.localeCompare(b));
     }
     if (manifests.length >0 ) {
-        if (Bun.file('packeges/.env')) {
+        if (Bun.file('packages/.env')) {
             console.log("Found packages .env file. Reading it");
-            config({ path: "./package/.env" });
+            config({ path: "./packages/.env" });
         }
         for (const manifest of manifests) {
             console.log(">>> Manifest:", manifest);

--- a/ide/deploy/scan.js
+++ b/ide/deploy/scan.js
@@ -19,6 +19,7 @@ import {glob} from 'glob';
 import {buildAction, buildZip, deployAction, deployPackage, deployProject} from './deploy.js';
 import {getOpenServerlessConfig} from './client.js';
 import {config} from "dotenv";
+import {syncDeployInfo} from "./syncDeployInfo";
 
 /**
  * This function will prepare and deploy the functions in `packages` directory.
@@ -166,5 +167,12 @@ export async function scan() {
             console.log(">>> Manifest:", manifest);
             deployProject(manifest);
         }
+    }
+
+    try {
+        // Save deployment information with the new structure
+        syncDeployInfo(packages, deployments);
+    } catch (error) {
+        console.error("Error saving deployment information:", error);
     }
 }

--- a/ide/deploy/syncDeployInfo.js
+++ b/ide/deploy/syncDeployInfo.js
@@ -1,0 +1,107 @@
+import {existsSync, mkdirSync, writeFileSync, readFileSync} from "fs";
+
+/**
+ * Synchronizes deployment information by saving the provided package and deployment data
+ * to a persisted `.ops/deployment.json` file. If the directory `.ops` does not exist, it
+ * is created before saving the information.
+ *
+ * The deployment information is organized by packages, with each package containing an array
+ * of its actions. This allows for more granular control when undeploying specific actions.
+ *
+ * @param {Set<string>} packages - A set of package names to include in the deployment data.
+ * @param {Set<string>} deployments - A set of deployment identifiers to include in the deployment data.
+ * @return {void}
+ */
+export function syncDeployInfo(packages, deployments) {
+    if (!existsSync('.ops')) {
+        mkdirSync('.ops', { recursive: true });
+    }
+
+    // Create a structured object with packages as keys and arrays of actions as values
+    const packageActions = {};
+
+    // Initialize packages with empty arrays
+    for (const pkg of packages) {
+        packageActions[pkg] = [];
+    }
+
+    // Add actions to their respective packages
+    for (const deployment of deployments) {
+        try {
+            const sp = deployment.split("/");
+            const spData = sp[sp.length - 1].split(".");
+            const name = spData[0];
+            const pkg = sp[1];
+
+            // If the package exists in our structure, add the action to it
+            if (packageActions[pkg]) {
+                packageActions[pkg].push(name);
+            }
+        } catch (error) {
+            console.error(`Error parsing deployment path ${deployment}:`, error);
+        }
+    }
+
+    const deploymentInfo = {
+        packages: Array.from(packages),
+        packageActions: packageActions
+    };
+
+    writeFileSync('.ops/deployment.json', JSON.stringify(deploymentInfo, null, 2));
+    console.log("> Saved deployment information to .ops/deployment.json");
+}
+
+/**
+ * Removes a specific action from the deployment information.
+ * 
+ * @param {string} actionName - The name of the action to remove in the format "package/action".
+ * @return {boolean} - True if the action was found and removed, false otherwise.
+ */
+export function removeActionFromDeployInfo(actionName) {
+    if (!existsSync('.ops/deployment.json')) {
+        console.error('Error: No deployment information found.');
+        return false;
+    }
+
+    try {
+        const deploymentInfo = JSON.parse(readFileSync('.ops/deployment.json', 'utf8'));
+        const [pkg, action] = actionName.split('/');
+
+        if (!deploymentInfo.packageActions || !deploymentInfo.packageActions[pkg]) {
+            console.error(`Error: Package ${pkg} not found in deployment information.`);
+            return false;
+        }
+
+        const actionIndex = deploymentInfo.packageActions[pkg].indexOf(action);
+        if (actionIndex === -1) {
+            console.error(`Error: Action ${action} not found in package ${pkg}.`);
+            return false;
+        }
+
+        // Remove the action from the package
+        deploymentInfo.packageActions[pkg].splice(actionIndex, 1);
+
+        // If the package has no more actions, remove it from the packages list
+        if (deploymentInfo.packageActions[pkg].length === 0) {
+            const packageIndex = deploymentInfo.packages.indexOf(pkg);
+            if (packageIndex !== -1) {
+                deploymentInfo.packages.splice(packageIndex, 1);
+            }
+            delete deploymentInfo.packageActions[pkg];
+        }
+
+        writeFileSync('.ops/deployment.json', JSON.stringify(deploymentInfo, null, 2));
+        console.log(`> Removed ${actionName} from deployment information.`);
+        return true;
+    } catch (error) {
+        console.error("Error updating deployment information:", error);
+        return false;
+    }
+}
+
+/**
+ * Cleans up deployment information by resetting and synchronizing deployment data.
+ */
+export function cleanupDeployInfo() {
+    syncDeployInfo(new Set(), new Set());
+}

--- a/ide/deploy/undeploy.js
+++ b/ide/deploy/undeploy.js
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { existsSync, readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { cleanupDeployInfo, removeActionFromDeployInfo } from "./syncDeployInfo";
+
+let dryRun = false;
+
+export function setDryRun(b) {
+  dryRun = b;
+}
+
+function exec(cmd) {
+  console.log("$", cmd);
+  if (!dryRun) {
+    spawnSync(cmd, { shell: true, env: process.env, stdio: "inherit" });
+  }
+}
+
+/**
+ * Undeploy a specific action and update the deployment information
+ * @param {string} actionName - The name of the action to undeploy in the format "package/action"
+ * @returns {boolean} true if successful, false if error
+ */
+export function undeployAction(actionName) {
+  console.log(`> Undeploying action: ${actionName}`);
+
+  try {
+    // Execute the undeploy command
+    exec(`$OPS action delete ${actionName}`);
+
+    // Update the deployment information
+    const success = removeActionFromDeployInfo(actionName);
+    if (success) {
+      console.log(`> Action ${actionName} successfully undeployed and removed from deployment information.`);
+      return true;
+    } else {
+      console.error(`> Action ${actionName} was undeployed but could not be removed from deployment information.`);
+      return false;
+    }
+  } catch (error) {
+    console.error(`Error undeploying action ${actionName}:`, error);
+    return false;
+  }
+}
+
+/**
+ * Undeploy actions and packages based on the deployment information in .ops/deployment.json
+ * If no deployment information is found, return an error
+ * @param {string} [specificAction] - Optional specific action to undeploy
+ * @returns {boolean} true if successful, false if error
+ */
+export function undeploy(specificAction) {
+  // If a specific action is provided, undeploy just that action
+  if (specificAction) {
+    return undeployAction(specificAction);
+  }
+
+  // Otherwise, undeploy all actions and packages from the current project
+  if (!existsSync('.ops/deployment.json')) {
+    console.error('Error: No OpenServerless project found in the current directory.');
+    console.error('Please run this command in a directory with an OpenServerless project.');
+    return false;
+  }
+
+  try {
+    const deploymentInfo = JSON.parse(readFileSync('.ops/deployment.json', 'utf8'));
+    const { packages, packageActions } = deploymentInfo;
+
+    if (!packages || !packageActions || packages.length === 0) {
+      console.error('Error: No deployment information found.');
+      return false;
+    }
+
+    console.log("> Undeploy actions and packages from the current project:");
+
+    // Undeploy actions
+    for (const pkg of packages) {
+      const actions = packageActions[pkg] || [];
+      for (const action of actions) {
+        const actionName = `${pkg}/${action}`;
+        console.log(`>> Undeploy action: ${actionName}`);
+        exec(`$OPS action delete ${actionName}`);
+      }
+    }
+
+    // Undeploy packages
+    for (const pkg of packages) {
+      console.log(`>> Undeploy package: ${pkg}`);
+      exec(`$OPS package delete ${pkg}`);
+    }
+
+    cleanupDeployInfo();
+    console.log("> Undeployment completed successfully.");
+    return true;
+  } catch (error) {
+    console.error("Error undeploy:", error);
+    return false;
+  }
+}

--- a/ide/docopts.md
+++ b/ide/docopts.md
@@ -44,7 +44,7 @@ Usage:
     ide login               login in openserverless
     ide devel               activate development mode
     ide deploy              deploy everything or just one action
-    ide undeploy            undeploy everything or just one action
+    ide undeploy            undeploy actions and packages from the current project or just one action
     ide clean               clean the temporay files
     ide setup               setup the ide
     ide serve               serve web area

--- a/ide/opsfile.yml
+++ b/ide/opsfile.yml
@@ -62,7 +62,7 @@ tasks:
         if test -e $PIDFILE
         then          
           PID=$(cat $PIDFILE)
-          
+
           if [ ! -z "$PID" ]; then
             if ps -p "$PID" > /dev/null;
             then
@@ -139,8 +139,8 @@ tasks:
         else 
           false
         fi
-  
-  
+
+
 
   poll:
     silent: true
@@ -189,35 +189,32 @@ tasks:
 
 
   undeploy:
-    desc: undeploy all the actions
-    prompt: "are you sure you want to remove all actions and packages?"
+    desc: undeploy actions and packages from the current project
     silent: true
     cmds:
       - task: prereq
-      - >
-        $OPS action list
-        | awk  'NR>1 { print $1}' 
-        | while read action ;
-        do  if {{.__dry_run}}
-            then echo '$' $OPS action delete "$action"
-            else $OPS action delete "$action"
-            fi
-        done
-      - >
-        $OPS package list
-        | awk  'NR>1 { print $1}'
-        | while read package ;
-        do if {{.__dry_run}}
-           then echo '$' $OPS package delete "$package" 
-           else $OPS package delete "$package" 
-           fi
-        done
+      - |
+        if {{.__dry_run}}
+        then DRY="--dry-run"
+        else DRY=""
+        fi
+
+        # Check if an action argument is provided
+        if test -n "{{._action_}}"
+        then
+          # Undeploy a specific action
+          echo "Undeploying specific action: {{._action_}}"
+          bun {{.TASKFILE_DIR}}/deploy/index.js "$OPS_PWD" -u -s "{{._action_}}" $DRY
+        else
+          # Undeploy all actions and packages from the current project
+          bun {{.TASKFILE_DIR}}/deploy/index.js "$OPS_PWD" -u $DRY
+        fi
       - >
         if {{.__dry_run}}
             then echo '$' $OPS util clean
             else $OPS util clean
           fi
-        
+
 
 
   clean:


### PR DESCRIPTION
The solution implements a project-specific undeployment mechanism that:

1. Keeps track of which packages and actions are deployed in the current project
2. Organizes actions by package in a more detailed structure
3. Allows removing a specific action and updating the deployment file
4. Returns an error if executed in a directory without an OpenServerless project

### Implementation Details

#### 1. Improved Structure for Deployment Information

When `ops ide deploy` is executed, the system now saves information about deployed packages and actions in a file with an improved structure:

- Information is stored in `.ops/deployment.json` in the project root
- The file contains a JSON object with:
    - `packages`: An array of package names that have been deployed
    - `packageActions`: An object that maps each package to an array of its actions

Example:
```json
{
    "packages": ["foo", "bar", "baz"],
    "packageActions": {
        "foo": ["hello", "world"],
        "bar": ["some_action"],
        "baz": []
    }
}
```

##### Sidenote 1: could be useful to automatically add the `.ops` dir to the .gitignore file when creating a project?
##### Sidenote 2: should we make this retro compatible for projects prior to this fix?

#### 2. Project-Specific Undeployment

When `ops ide undeploy` is executed without arguments:

- The system checks for the existence of `.ops/deployment.json`
- If the file exists, it reads the deployment information
- It removes only the actions and packages listed in the file
- If the file doesn't exist, it returns an error message indicating that no OpenServerless project was found

#### 3. Single Action Undeployment

When `ops ide undeploy contact/index` is executed:

- The system removes the specific action
- It updates the `.ops/deployment.json` file to remove the action from the list
- If the package no longer has actions, it also removes the package from the list

references apache/openserverless#117