### PR TITLE
Add ops config task to configure nuvolaris.ingresslb

### DIFF
--- a/config/docopts.md
+++ b/config/docopts.md
@@ -26,6 +26,7 @@ Configure OpenServerless
 Usage:
   config (enable|disable) [--all] [--redis] [--mongodb] [--minio] [--cron] [--static] [--postgres] [--prometheus] [--slack] [--mail] [--affinity] [--tolerations] [--quota] [--milvus] 
   config apihost (<apihost>|auto) [--tls=<email>] [--protocol=<http/https>|auto]
+  config ingresslb (<ingresslb>|auto)
   config runtimes [<runtimesjson>]  
   config slack [--apiurl=<slackapiurl>] [--channel=<slackchannel>]
   config mail  [--mailuser=<mailuser>] [--mailpwd=<mailpwd>] [--mailfrom=<mailfrom>] [--mailto=<mailto>]
@@ -53,6 +54,7 @@ Usage:
 
 ```
   config apihost          configure the apihost (auto: auto assign) and enable tls
+  config ingresslb        configure the ingress LB (auto: auto discover). Provide a custom ingress namespace and a custom ingress controller service (e.g. my-ns/my-svc)
   config runtime          show the current runtime.json or import the <runtime-json> if provided
   config enable           enable OpenServerless services to install
   config disable          disable OpenServerless services to install

--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -39,7 +39,12 @@ tasks:
         fi        
       - config -dump | rg OPERATOR_COMPONENT_TLS
       - config -dump | rg OPERATOR_CONFIG_HOSTPROTOCOL
-
+  ingresslb:
+    silent: true
+    cmds:
+      - echo "cfg {{._ingresslb_}}"
+      - config OPERATOR_CONFIG_INGRESSLB="{{._ingresslb_}}"
+      - config -dump | rg OPERATOR_CONFIG_INGRESSLB
   enable:
     silent: true
     cmds:

--- a/setup/kubernetes/roles/operator-roles.yaml
+++ b/setup/kubernetes/roles/operator-roles.yaml
@@ -101,6 +101,11 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["get","patch","list","update","watch","create","delete"]      
 
+# required for patching kopf related resources
+- apiGroups: ["zalando.org"]
+  resources: ["kopfpeerings"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/setup/kubernetes/whisk.yaml
+++ b/setup/kubernetes/whisk.yaml
@@ -30,6 +30,7 @@ spec:
       protocol: ${OPERATOR_CONFIG_HOSTPROTOCOL:-auto}
       affinity: ${OPERATOR_CONFIG_AFFINITY:-false}
       tolerations: ${OPERATOR_CONFIG_TOLERATIONS:-false}
+      ingresslb: ${OPERATOR_CONFIG_INGRESSLB:-auto}
   components:
     # start openwhisk controller
     openwhisk: true


### PR DESCRIPTION
Closes apache/openserverless#138 by introducing support for the OPERATOR_CONFIG_INGRESSLB variable.

This variable is used to configure the `ingresslb` key under the `nuvolaris` section in setup/kubernetes/whisk.yaml.