### PR TITLE
feat: slim mode

### DIFF
--- a/config/docopts.md
+++ b/config/docopts.md
@@ -46,7 +46,8 @@ Usage:
   config aks [--project=<project>] [--name=<name>] [--region=<region>] [--count=<count>]  [--vm=<vm>] [--disk=<disk>] [--key=<key>]
   config (status|export|reset)
   config use [<n>] [--delete] [--rename=<rename>]
-  config minimal  
+  config minimal
+  config slim  
 ```
 
 ## Commands
@@ -78,6 +79,7 @@ Usage:
   config export           export all the variables
   config use              use a different kubernetes cluster among those you created
   config minimal          shortcut for ops config enabling only redis,mongodb,minio,cron,static,postgres
+  config slim             shortcut for ops config slim, but adding lightweight milvus and other sizing improvements
 ```
 
 ## Options

--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1118,4 +1118,28 @@ tasks:
       config OPERATOR_COMPONENT_STATIC=true
     - |
       config OPERATOR_COMPONENT_POSTGRES=true
-    - task: status                               
+    - task: status
+
+  slim:
+    silent: true
+    cmds:
+    - |
+      config OPERATOR_COMPONENT_INVOKER=false
+      config OPERATOR_COMPONENT_ZOOKEEPER=false
+      config OPERATOR_COMPONENT_KAFKA=false      
+      config OPERATOR_COMPONENT_REDIS=true
+      config OPERATOR_COMPONENT_MONGODB=true
+      config OPERATOR_COMPONENT_MINIO=true
+      config OPERATOR_COMPONENT_CRON=false 
+      config OPERATOR_COMPONENT_STATIC=true
+      config OPERATOR_COMPONENT_POSTGRES=true
+      config OPERATOR_COMPONENT_ETCD=true
+      config OPERATOR_COMPONENT_MILVUS=true
+      config OPERATOR_CONFIG_AFFINITY=true
+      config OPERATOR_CONFIG_TOLERATIONS=true  
+      config ETCD_CONFIG_REPLICAS=1
+      config POSTGRES_CONFIG_REPLICAS=1 
+      config OPERATOR_CONFIG_SLIM=true
+    - |
+      config OPENWHISK_INVOKER_CONTAINER_POOL_MEMORY=6
+    - task: status

--- a/opsroot.json
+++ b/opsroot.json
@@ -5,7 +5,7 @@
 	     "coreutils": "arch b2sum b3sum base32 basename basenc cat chgrp chmod chown chroot cksum comm cp csplit cut date dd df dir dircolors dirname du env expand expr factor fmt fold groups hashsum head hostid hostname id install join kill link ln logname ls md5sum mkdir mkfifo mknod mktemp more mv nice nl nohup nproc numfmt od paste pathchk pinky pr printenv printf ptx pwd readlink realpath rm rmdir seq sha1sum sha224sum sha256sum sha3-224sum sha3-256sum sha3-384sum sha3-512sum sha384sum sha3sum sha512sum shake128sum shake256sum shred shuf sleep sort split stat stdbuf stty sum sync tac tail tee timeout touch tr truncate tsort tty uname unexpand uniq unlink uptime users vdir wc who whoami yes"
        },
        "images": {
-         "operator": "apache/openserverless-operator:0.1.0-incubating.2504061956",
+         "operator": "apache/openserverless-operator:0.1.0-incubating.2506170946",
          "controller": "ghcr.io/nuvolaris/openwhisk-controller:3.1.0-mastrogpt.2402101445",
          "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445"
         }

--- a/setup/kubernetes/crds/whisk-crd.yaml
+++ b/setup/kubernetes/crds/whisk-crd.yaml
@@ -82,7 +82,10 @@ spec:
                       type: boolean
                     tolerations:
                       description: enable/disable openwhisk toleration. This flag can be true only on multinode cluster deployment. Default to false
-                      type: boolean                                                                                                                                         
+                      type: boolean
+                    slim:
+                      description: boolean flag to enable/disable nuvolaris slim mode. Defaulted to false
+                      type: boolean
                   required:
                   - password    
                 components:

--- a/setup/kubernetes/opsfile.yml
+++ b/setup/kubernetes/opsfile.yml
@@ -189,6 +189,7 @@ tasks:
       - "kubectl apply  -f common -f roles -f crds"
 
   storageclass-env:
+    silent: true
     vars:
       OP_VOL_STORAGE_CLASS:
         sh: |
@@ -276,6 +277,7 @@ tasks:
 
   permission:
     desc: assign permissions (required cluster-admin)
+    silent: true
     cmds:
       - task: context
       - task: prepare

--- a/setup/kubernetes/roles/openwhisk-core-roles.yaml
+++ b/setup/kubernetes/roles/openwhisk-core-roles.yaml
@@ -16,17 +16,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: openwhisk-core
+#   namespace: nuvolaris
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: view
+# subjects:
+#   - kind: ServiceAccount
+#     name:  openwhisk-core
+#     namespace: nuvolaris
+---    
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nuvolaris-openwhisk-core
+  namespace: nuvolaris
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openwhisk-core-role
+  namespace: nuvolaris
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openwhisk-core
+  name: openwhisk-controller-role-rb
   namespace: nuvolaris
 roleRef:
+  kind: Role
+  name: openwhisk-core-role
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view
 subjects:
   - kind: ServiceAccount
-    name:  openwhisk-core
+    name:  nuvolaris-openwhisk-core
     namespace: nuvolaris
+

--- a/setup/kubernetes/whisk.yaml
+++ b/setup/kubernetes/whisk.yaml
@@ -28,19 +28,20 @@ spec:
       storageclass: ${OPERATOR_CONFIG_STORAGECLASS:-auto}
       provisioner: ${OPERATOR_CONFIG_STORAGEPROVISIONER:-auto}
       protocol: ${OPERATOR_CONFIG_HOSTPROTOCOL:-auto}
+      slim: ${OPERATOR_CONFIG_SLIM:-false}
       affinity: ${OPERATOR_CONFIG_AFFINITY:-false}
-      tolerations: ${OPERATOR_CONFIG_TOLERATIONS:-false}
+      tolerations: ${OPERATOR_CONFIG_TOLERATIONS:-false}      
   components:
     # start openwhisk controller
     openwhisk: true
     # start openwhisk invoker
-    invoker: true    
+    invoker: ${OPERATOR_COMPONENT_INVOKER:-true}        
     # start couchdb
     couchdb: true
     # start zookeeper
-    zookeeper: true    
+    zookeeper: ${OPERATOR_COMPONENT_ZOOKEEPER:-true}    
     # start kafka
-    kafka: true
+    kafka: ${OPERATOR_COMPONENT_KAFKA:-true}
     # prometheus monitoring enabled or not
     monitoring: ${OPERATOR_COMPONENT_PROMETHEUS:-false}        
     # start mongodb
@@ -234,5 +235,6 @@ spec:
     password:
       root: $SECRET_MILVUS_ROOT     
       s3: $SECRET_MILVUS_S3
+      etcd: $SECRET_ETCD_ROOT
     nuvolaris:
       password: $SECRET_MILVUS_NUVOLARIS  


### PR DESCRIPTION
added a slim mode as requested by https://github.com/apache/openserverless/issues/131.

I've introduced an: `ops config slim` that will configure the operator to deploy a "slim"  OpenServerless installation:
- no kafka, zookeeper, invoker
- controller in lean mode
- 1 postgres (with included ferret) instance 
- 1 minio 
- 1 etcd + 1 milvus in standalone mode

Resource consumption seems to be less than 4Gb RAM.