### PR TITLE
Implement ops admin compact

### DIFF
--- a/admin/docopts.md
+++ b/admin/docopts.md
@@ -29,12 +29,14 @@ You can create namespaces and choose which services to enable.
 Usage:
   admin adduser <username> <email> <password> [--all] [--redis] [--mongodb] [--minio] [--postgres] [--milvus] [--storagequota=<quota>|auto]
   admin deleteuser <username>
+  admin compact [--ttl=<ttl>|10]
 ```
 
 ## Commands
 ```
   admin adduser       create a new user in OpenServerless with the username, email and password provided
   admin deleteuser    delete a user from the OpenServerless installation via the username provided
+  admin compact       create a one shot job which executes couchdb compact against all available dbs
 ```
 
 ## Options
@@ -46,4 +48,5 @@ Usage:
   --postgres              enable postgres
   --milvus                enable milvus vector db
   --storagequota=<quota>
+  --ttl=<seconds>             modify the job ttl after finished (defaults to 10 seconds)
 ```

--- a/admin/kubernetes/compact-job.yaml
+++ b/admin/kubernetes/compact-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: couchdb-compact-job
+  namespace: nuvolaris
+  labels:
+    app: couchdb-compact-job
+spec:
+  ttlSecondsAfterFinished: ${JOB_TTL}
+  template:
+    metadata:
+      labels:
+        app: couchdb-compact-job
+    spec:
+      containers:
+      - name: couchdb-compactor
+        image: alpine:3.14
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            apk add --no-cache curl jq;
+            echo "COUCHDB_HOST: $COUCHDB_HOST";
+            echo "COUCHDB_USER: $$COUCHDB_USER";
+
+            # List all databases
+            databases=$(curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" "http://$$COUCHDB_HOST/_all_dbs" | jq -r '.[]');
+
+            echo "Found databases: $databases";
+
+            # Trigger compact operation for each database
+            for db in $$databases; do
+              echo "Triggering compact for database: $db";
+              curl -s -X POST -H "Content-Type: application/json" -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" "http://$$COUCHDB_HOST/$$db/_compact" -d '{}';
+              echo "Compaction triggered for $$db";
+            done;
+            echo "CouchDB compat script finished.";
+        env:
+        - name: COUCHDB_HOST
+          value: "${COUCHDB_HOST:-couchdb}:${COUCHDB_PORT:-5984}"
+        - name: COUCHDB_USER
+          valueFrom:
+            secretKeyRef:
+              name: ${COUCHDB_SECRET_NAME}
+              key: db_username
+        - name: COUCHDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ${COUCHDB_SECRET_NAME}
+              key: db_password
+      restartPolicy: OnFailure

--- a/admin/opsfile.yml
+++ b/admin/opsfile.yml
@@ -154,3 +154,26 @@ tasks:
         else 
           kubectl apply -f _user-crd.yaml          
         fi
+
+  compact:
+    silent: true
+    vars:
+      COUCHDB_HOST: couchdb
+      COUCHDB_PORT: "5984"
+      JOB_TTL: "10" # cleanup job after 10 seconds
+    cmds:
+      - |
+        JOB_TTL={{.__ttl}}
+        if test -z $JOB_TTL; then
+          JOB_TTL=10
+        fi
+        export COUCHDB_HOST={{.COUCHDB_HOST}}
+        export COUCHDB_PORT="{{.COUCHDB_PORT}}"
+        export JOB_TTL=$JOB_TTL
+        export COUCHDB_SECRET_NAME=$(kubectl get secrets -o name | awk -F'/' '{print $2}' | rg couchdb-auth-)
+        envsubst -i kubernetes/compact-job.yaml -o kubernetes/_compact-job.yaml
+        if {{.DRY}}
+        then cat kubernetes/_compact-job.yaml
+        else
+          kubectl apply -f kubernetes/_compact-job.yaml
+        fi


### PR DESCRIPTION
This task is implemented by using a kubernetes job manifest.

## Manifest params
- COUCHDB_USER and COUCHDB_PASSWORD are injected by prior retrieving the couchdb-secret in the nuvolaris namespace
- COUCHDB_HOST and COUCHDB_PORT are filled from withing the task vars
- JOB_TTL can be supplied by the user with the flag `--ttl` (e.g. ops admin compact --ttl=100

## Job image
The job uses alpine:3.14 with the `curl` and `jq` utilities.

#### Sidenotes: compaction in couchdb can be done automatically via [smoosh](https://docs.couchdb.org/en/stable/maintenance/compaction.html#automatic-compaction)

closes apache/openserverless#134
