### PR TITLE
chore: typo in slim config

### DIFF
--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1141,5 +1141,5 @@ tasks:
       config POSTGRES_CONFIG_REPLICAS=1 
       config OPERATOR_CONFIG_SLIM=true
     - |
-      config OPENWHISK_INVOKER_CONTAINER_POOL_MEMORY=6
+      config OPENWHISK_INVOKER_CONTAINER_POOL_MEMORY=6g
     - task: status


### PR DESCRIPTION
fixed a typo in OPENWHISK_INVOKER_CONTAINER_POOL_MEMORY inside the slim configuration