### PR TITLE
Delete task optimizations

### DIFF
--- a/setup/docker/opsfile.yml
+++ b/setup/docker/opsfile.yml
@@ -89,6 +89,15 @@ tasks:
     silent: true
     desc: destroy the Apache OpenServerless cluster in Docker
     cmds:
+    - |
+      if ! test -e "$OPS_TMP/kind.kubeconfig"; then
+        echo "ops kind kubeconfig not found"
+        exit 1
+      fi
+      if [ "$KUBECONFIG" = "$HOME/.kube/config" ]; then
+        echo "backup kube config"
+        cp ~/.kube/config ~/.kube/config.bak
+      fi
     - kind delete clusters nuvolaris
     - rm "$KUBECONFIG" "$OPS_TMP/kind.kubeconfig"
 


### PR DESCRIPTION
- exit with an error when the `kind.kubeconfig` file doesn't exist
- backup the kubeconfig file when $KUBECONFIG resolves to the user's home .kube/config file.

related to apache/openserverless#140