### PR TITLE
streamer deploy

### DIFF
--- a/opsroot.json
+++ b/opsroot.json
@@ -7,7 +7,8 @@
        "images": {
          "operator": "apache/openserverless-operator:0.1.0-incubating.2506240723",
          "controller": "ghcr.io/nuvolaris/openwhisk-controller:3.1.0-mastrogpt.2402101445",
-         "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445"
+         "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445",
+         "streamer": "registry.hub.docker.com/apache/openserverless-streamer:0.1.0-incubating.2505031325"
         }
     }
 }

--- a/setup/kubernetes/opsfile.yml
+++ b/setup/kubernetes/opsfile.yml
@@ -89,6 +89,10 @@ env:
       fi
 
 tasks:
+  
+  streamer:
+    desc: deploy streamer
+  
   status:
     desc: show nuvolaris cluster status
     silent: true

--- a/setup/kubernetes/streamer/k3s-template.yaml
+++ b/setup/kubernetes/streamer/k3s-template.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingressClassName: traefik
+    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+    traefik.ingress.kubernetes.io/transport.respondingTimeouts.idleTimeout: "600"
+    traefik.ingress.kubernetes.io/transport.respondingTimeouts.readTimeout: "600"
+    traefik.ingress.kubernetes.io/transport.respondingTimeouts.writeTimeout: "600"
+  name: ${USERNAME:-nuvolaris}-streamer-api-ingress
+  namespace: nuvolaris
+spec:
+  rules:
+  - host: stream.${STREAMER_API_HOSTNAME:-localhost}
+    http:
+      paths:
+      - backend:
+          service:
+            name: ${USERNAME:-nuvolaris}-streamer-api
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix

--- a/setup/kubernetes/streamer/nginx-template.yaml
+++ b/setup/kubernetes/streamer/nginx-template.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 48m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+  name: ${USERNAME:-nuvolaris}-streamer-api-ingress
+  namespace: nuvolaris
+spec:
+  ingressClassName: nginx
+  rules:
+  - #
+    host: stream.${STREAMER_API_HOSTNAME:-localhost}
+    http:
+      paths:
+      - backend:
+          service:
+            name: ${USERNAME:-nuvolaris}-streamer-api
+            port:
+              number: 8080
+        path: /system
+        pathType: Prefix
+

--- a/setup/kubernetes/streamer/nginx-template.yaml
+++ b/setup/kubernetes/streamer/nginx-template.yaml
@@ -27,7 +27,7 @@ spec:
   ingressClassName: nginx
   rules:
   - #
-    host: stream.${STREAMER_API_HOSTNAME:-localhost}
+    host: stream.${STREAMER_API_HOSTNAME:-localhost}    
     http:
       paths:
       - backend:
@@ -35,6 +35,6 @@ spec:
             name: ${USERNAME:-nuvolaris}-streamer-api
             port:
               number: 8080
-        path: /system
+        path: /
         pathType: Prefix
 

--- a/setup/kubernetes/streamer/opsfile.yml
+++ b/setup/kubernetes/streamer/opsfile.yml
@@ -34,7 +34,16 @@ env:
       fi
 
   STREAMER_API_HOSTNAME: 
-      sh: ops util kubectl -- -n nuvolaris get ingress/apihost -o jsonpath='{.spec.rules[0].host}'
+      sh: |
+        ops util kubectl -- -n nuvolaris get ingress/apihost -o jsonpath='{.spec.rules[0].host}'       
+  
+  OW_APIHOST:
+    sh: |
+      HOST=$(ops util kubectl -- -n nuvolaris get ingress/apihost -o jsonpath='{.spec.rules[0].host}')
+      if [ $OPERATOR_COMPONENT_INVOKER = true ]; 
+        then echo "$HOST"
+        else  echo "http://controller:3233"
+      fi
 
   INGRESS_TYPE:
     sh: |
@@ -46,23 +55,30 @@ env:
 tasks:
 
   deploy:
+    silent: true
     ignore_error: false
     desc: deploy the streamer 
     cmds:
-    - env | grep IMAGES_STREAMER
-    - envsubst -i streamer-template.yaml -o _streamer.yaml
-    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml
-    - kubectl -n nuvolaris apply -f _streamer.yaml
-    - kubectl -n nuvolaris apply -f _ingress.yaml
+    - env | grep IMAGES_STREAMER > /dev/null 2>&1 || 
+      (echo "IMAGES_STREAMER is not set. Please set it to the desired image version." && exit 1)
+    - envsubst -i streamer-template.yaml -o _streamer.yaml > /dev/null 2>&1
+    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml > /dev/null 2>&1
+    - kubectl -n nuvolaris apply -f _streamer.yaml > /dev/null 2>&1
+    - kubectl -n nuvolaris apply -f _ingress.yaml > /dev/null 2>&1
+    - |
+      echo "Streamer API deployed with HOSTNAME: ${STREAMER_API_HOSTNAME} and OW_APIHOST: ${OW_APIHOST}"
 
   undeploy:
+    silent: true
     desc: undeploy the streamer 
     ignore_error: false
     cmds:
-    - envsubst -i streamer-template.yaml -o _streamer.yaml
-    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml
-    - kubectl -n nuvolaris delete -f _streamer.yaml
-    - kubectl -n nuvolaris delete -f _ingress.yaml
+    - envsubst -i streamer-template.yaml -o _streamer.yaml > /dev/null 2>&1
+    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml > /dev/null 2>&1
+    - kubectl -n nuvolaris delete -f _streamer.yaml > /dev/null 2>&1
+    - kubectl -n nuvolaris delete -f _ingress.yaml > /dev/null 2>&1
+    - |
+      echo "Streamer API undeployed"
 
   update:
     silent: true

--- a/setup/kubernetes/streamer/opsfile.yml
+++ b/setup/kubernetes/streamer/opsfile.yml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+version: '3'
+
+vars:
+  VAR: ""
+  MSG: ""
+  VAL: ""
+  RETRY: 100
+  TIMEOUT: 15s
+  CONTEXT: ""
+
+env:
+
+  KUBECONFIG:
+    sh: |
+      if test -e $(realpath "$OPS_TMP/kubeconfig")
+      then echo $(realpath "$OPS_TMP/kubeconfig")
+      else echo ~/.kube/config
+      fi
+
+  STREAMER_API_HOSTNAME: 
+      sh: ops util kubectl -- -n nuvolaris get ingress/apihost -o jsonpath='{.spec.rules[0].host}'
+
+  INGRESS_TYPE:
+    sh: |
+      case "$(kubectl get ingressclass -ojsonpath='{.items[0].spec.controller}')" in
+        k8s.io/ingress-nginx)  echo "nginx" ;;
+        traefik.io/ingress-controller) echo "k3s" ;;
+      esac
+
+tasks:
+
+  deploy:
+    ignore_error: false
+    desc: deploy the streamer 
+    cmds:
+    - env | grep IMAGES_STREAMER
+    - envsubst -i streamer-template.yaml -o _streamer.yaml
+    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml
+    - kubectl -n nuvolaris apply -f _streamer.yaml
+    - kubectl -n nuvolaris apply -f _ingress.yaml
+
+  undeploy:
+    desc: undeploy the streamer 
+    ignore_error: false
+    cmds:
+    - envsubst -i streamer-template.yaml -o _streamer.yaml
+    - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml
+    - kubectl -n nuvolaris delete -f _streamer.yaml
+    - kubectl -n nuvolaris delete -f _ingress.yaml
+
+  update:
+    silent: true
+    desc: update the streamer 
+    cmds:
+      - task: deploy
+      - kubectl -n nuvolaris rollout restart statefulset nuvolaris-streamer-api
+    preconditions:      
+      - sh: '[ $IMAGES_STREAMER != $CURRENT_STREAMER_VERSION ]'
+        msg: "Current nuvolaris streamer API stateful set it is already updated to newest version. Request ignored."
+    env:
+      CURRENT_STREAMER_VERSION:
+        sh: |
+          echo $(kubectl -n nuvolaris get pod/nuvolaris-streamer-api-0 -ojsonpath='{.spec.containers[0].image}')
+                      
+  

--- a/setup/kubernetes/streamer/streamer-template.yaml
+++ b/setup/kubernetes/streamer/streamer-template.yaml
@@ -43,7 +43,7 @@ spec:
               name: streamer
           env:
           - name: "OW_APIHOST"
-            value: "${STREAMER_API_HOSTNAME:-localhost}"
+            value: "${OW_APIHOST-http://controller:3233}"
           - name: "HTTP_SERVER_PORT"
             value: "8080"
           - name: "STREAMER_ADDR"

--- a/setup/kubernetes/streamer/streamer-template.yaml
+++ b/setup/kubernetes/streamer/streamer-template.yaml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${USERNAME:-nuvolaris}-streamer-api
+  namespace: nuvolaris
+  labels:
+    app: ${USERNAME:-nuvolaris}-streamer-api
+spec:  
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${USERNAME:-nuvolaris}-streamer-api
+  template:
+    metadata:
+      labels:
+        name: ${USERNAME:-nuvolaris}-streamer-api
+        app: ${USERNAME:-nuvolaris}-streamer-api
+    spec:
+      serviceAccount: default
+      containers:
+        - name: ${USERNAME:-nuvolaris}-streamer-api
+          image: ${IMAGES_STREAMER}
+          imagePullPolicy: Always
+          command: ["/streamer"]
+          ports:
+            - containerPort: 8080
+              name: streamer
+          env:
+          - name: "OW_APIHOST"
+            value: "${STREAMER_API_HOSTNAME:-localhost}"
+          - name: "HTTP_SERVER_PORT"
+            value: "8080"
+          - name: "STREAMER_ADDR"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: "CORS_ENABLED"
+            value: "1"                                                                                                                                                                                      
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${USERNAME:-nuvolaris}-streamer-api
+  namespace: nuvolaris
+spec:
+  ports:
+    - name: streamer
+      port: 8080
+  selector:
+    app: ${USERNAME:-nuvolaris}-streamer-api

--- a/setup/opsfile.yml
+++ b/setup/opsfile.yml
@@ -101,6 +101,7 @@ tasks:
       - $OPS config apihost miniops.me --protocol=http
       - $OPS setup devcluster
       - $OPS setup nuvolaris add-user
+      - $OPS setup kubernetes streamer deploy
 
   devcluster:
     vars:


### PR DESCRIPTION
i've completed the integration of streamer tasks inside the `ops setup mini` command.

In particular, integrated the streamer tasks inside `ops setup kubernetes streamer`

**Notice**
the  OW_APIHOST variable inside `[streamer/opsfile.yml](https://github.com/apache/openserverless-task/pull/112/files#diff-086830ae97d646eba9b8597b4bc9987e381d09a2b8ed58b60541e762dfec63a3) is filled in checking if the controller is deployed in standalone mode (this happens when the `OPERATOR_COMPONENT_INVOKER` is set to false).
 
Tested the streamer using https://github.com/mastrogpt/streamer-examples sample project