### PR TITLE
fix: missing s3 ingress in mini

### DIFF
--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1138,6 +1138,7 @@ tasks:
       config OPERATOR_COMPONENT_POSTGRES=true
       config OPERATOR_COMPONENT_ETCD=true
       config OPERATOR_COMPONENT_MILVUS=true
+      config MINIO_CONFIG_INGRESS_S3=true
       config ETCD_CONFIG_REPLICAS=1
       config POSTGRES_CONFIG_REPLICAS=1 
       config OPERATOR_CONFIG_SLIM=true


### PR DESCRIPTION
Added config option MINIO_CONFIG_INGRESS_S3=trye to slim configuration. Resolves https://github.com/apache/openserverless/issues/146