### PR TITLE
Implements apache/openserverless#158

### DIFF
--- a/config/docopts.md
+++ b/config/docopts.md
@@ -32,7 +32,7 @@ Usage:
   config volumes [--couchdb=<couchdb>] [--kafka=<kafka>] [--pgvol=<postgres>] [--storage=<storage>] [--alerting=<alerting>] [--zookeeper=<zookeeper>] [--redisvol=<redis>] [--mongodbvol=<mongodb>] [--etcdvol=<etcd>] [--mvvol=<milvus>] [--mvzookvol=<milvuszook>] [--pulsarjournalvol=<pulsarjournal>] [--pulsarledgelvol=<pulsarledge>]  
   config controller [--javaopts=<javaopts>] [--loglevel=<loglevel>] [--replicas=<replicas>]
   config invoker [--javaopts=<javaopts>] [--poolmemory=<poolmemory>] [--timeoutsrun=<timeoutsrun>] [--timeoutslogs=<timeoutslogs>] [--loglevel=<loglevel>] [--replicas=<replicas>]
-  config limits [--time=<time>] [--memory=<memory>] [--sequencelength=<sequencelength>] [--perminute=<perminute>] [--concurrent=<concurrent>] [--triggerperminute=<triggerperminute>] [--activation_max_payload=<activation_max_payload>]
+  config limits [--time=<time>] [--memory=<memory>] [--sequencelength=<sequencelength>] [--perminute=<perminute>] [--concurrent=<concurrent>] [--triggerperminute=<triggerperminute>] [--activation_max_payload=<activation_max_payload>] [--blackbox_fraction=<blackbox_fraction>]
   config storage [--class=<storage_class>] [--provisioner=<storage_provisioner>]
   config postgres [--failover] [--backup] [--schedule=<cron_expression>] [--replicas=<replicas>]
   config minio [--s3] [--console]

--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1000,6 +1000,14 @@ tasks:
               Specifies nuvolaris controller activation options (Defaults to 1Mb)
         VAL: "{{.__activation_max_payload}}"
         DEF: "1048576"
+    - task: read
+      vars:
+        MSG: "Openwhisk Load Balancer BlackBox fraction"
+        VAR: "OPENWHISK_LB_BLACKBOX_FRACTION"
+        HINT: | 
+              Specifies OpenWhisk Load Balancer Blackbox fraction (Defaults to 100%)
+        VAL: "{{.__blackbox_fraction}}"
+        DEF: "100%"        
 
   storage:
     silent: true

--- a/setup/kubernetes/whisk.yaml
+++ b/setup/kubernetes/whisk.yaml
@@ -125,7 +125,7 @@ spec:
         limit-std: "${OPENWHISK_ACTION_MEMORY_LIMIT_STD:-256m}"
         limit-max: "${OPENWHISK_ACTION_MEMORY_LIMIT_MAX:-2048m}"
       loadbalancer:
-        blackbox-fraction : "10%"
+        blackbox-fraction : "${OPENWHISK_LB_BLACKBOX_FRACTION:100%}"
         timeout-factor: 2                
     controller:
       javaOpts: "$OPENWHISK_CONTROLLER_JAVA_OPTS"


### PR DESCRIPTION
feat: sets load balancer blackbox fraction to 100% by default. This parameter it is already handled by the openserverless-operator as a configurable value, defaulting to 10% if not set into the whisk.yaml.