### PR TITLE
chore: time limit 10 min

### DIFF
--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1200,6 +1200,7 @@ tasks:
       config OPERATOR_CONFIG_SLIM=true
       config OPERATOR_COMPONENT_REGISTRY=true
       config REGISTRY_CONFIG_SECRET_PUSH_PULL="$(random --str 12)"
+      config OPENWHISK_TIME_LIMIT_MAX="10min"
     - |
       config OPENWHISK_INVOKER_CONTAINER_POOL_MEMORY=6g
     - task: status


### PR DESCRIPTION
Added a configuration to increase at 10 minutes the openwhisk max time limit. Now is possible to pass a --timeout up to 600000. This resolves https://github.com/apache/openserverless/issues/162