### PR TITLE
chore: updated systemapi image

### DIFF
--- a/opsroot.json
+++ b/opsroot.json
@@ -9,7 +9,7 @@
          "controller": "ghcr.io/nuvolaris/openwhisk-controller:3.1.0-mastrogpt.2402101445",
          "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445",
          "streamer": "registry.hub.docker.com/apache/openserverless-streamer:0.1.0-incubating.2505031325",
-         "systemapi": "registry.hub.docker.com/nuvolaris/openserverless-admin-api:0.1.0-incubating.2507271455"
+         "systemapi": "registry.hub.docker.com/apache/openserverless-admin-api:0.1.0-incubating.2508161629"
         }
     }
 }

--- a/setup/kubernetes/roles/nuvolaris-wsku-roles.yaml
+++ b/setup/kubernetes/roles/nuvolaris-wsku-roles.yaml
@@ -29,6 +29,14 @@ rules:
 - apiGroups: ["nuvolaris.org"]
   resources: ["whisksusers","whisksusers/status","*/finalizers"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# assign the possibility to operate on configmaps (admin api)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]  
+# assign the possibility to operate on jobs (admin api)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 kind: RoleBinding

--- a/setup/nuvolaris/system-api/docopts.md
+++ b/setup/nuvolaris/system-api/docopts.md
@@ -24,15 +24,15 @@ Manage installation of the OpenServerless system admin api
 
 ```text
 Usage:
-  admin-api deploy
-  admin-api undeploy  
-  admin-api update  
+  system-api deploy
+  system-api undeploy  
+  system-api update  
 ```
 
 ## Commands
 
 ```
-  admin-api deploy              enable setup options for the OpenServerless System Api
-  admin-api undeploy            disable setup options for the OpenServerless System Api
-  admin-api update              Update the api deployment if a newer version is available
+  system-api deploy              enable setup options for the OpenServerless System Api
+  system-api undeploy            disable setup options for the OpenServerless System Api
+  system-api update              Update the api deployment if a newer version is available
 ```

--- a/setup/nuvolaris/system-api/opsfile.yml
+++ b/setup/nuvolaris/system-api/opsfile.yml
@@ -58,9 +58,9 @@ tasks:
     - test -n "$IMAGES_SYSTEMAPI" || die "IMAGES_SYSTEMAPI is not set. Please set it to the desired image version."
     - envsubst -i api-template.yaml -o _api.yaml > /dev/null 2>&1
     - envsubst -i ${INGRESS_TYPE}-template.yaml -o _ingress.yaml > /dev/null 2>&1
-    - kubectl -n nuvolaris apply -f _api.yaml
+    - $OPS debug kube ctl CMD="-n nuvolaris apply -f $OPS_PWD/setup/nuvolaris/system-api/_api.yaml"
     #- cat _ingress.yaml
-    - kubectl -n nuvolaris apply -f _ingress.yaml
+    - $OPS debug kube ctl CMD="-n nuvolaris apply -f $OPS_PWD/setup/nuvolaris/system-api/_ingress.yaml"
     - |
       echo "Admin API deployed with HOSTNAME: ${SYS_API_HOSTNAME}/system"
   
@@ -69,21 +69,21 @@ tasks:
     desc: undeploy the admin api
     ignore_error: true
     cmds:
-    - kubectl -n nuvolaris delete sts/nuvolaris-system-api ing/nuvolaris-system-api-ingress svc/nuvolaris-system-api
+    - $OPS debug kube ctl CMD="-n nuvolaris delete sts/nuvolaris-system-api ing/nuvolaris-system-api-ingress svc/nuvolaris-system-api"
     - |
-      echo "System API undeployed"
+      echo "System Admin API undeployed"
   
 
   update:
     silent: true
-    desc: update the OpenServerless Admin Api stateful set
+    desc: update the OpenServerless System Admin Api Stateful Set
     cmds:
       - task: deploy
-      - kubectl -n nuvolaris rollout restart statefulset nuvolaris-system-api
+      - $OPS debug kube ctl CMD="-n nuvolaris rollout restart statefulset nuvolaris-system-api"
     preconditions:      
       - sh: '[ $IMAGES_SYSTEMAPI != $CURRENT_API_VERSION ]'
-        msg: "Current OpenServerless system API stateful set it is already updated to newest version. Request ignored."
+        msg: "Current OpenServerless System API stateful set it is already updated to newest version. Request ignored."
     env:
       CURRENT_API_VERSION:
         sh: |
-          echo $(kubectl -n nuvolaris get pod/nuvolaris-system-api-0 -ojsonpath='{.spec.containers[0].image}')
+          echo $($OPS debug kube ctl CMD="-n nuvolaris get sts/nuvolaris-system-api -ojsonpath='{.spec.template.spec.containers[0].image}'")


### PR DESCRIPTION
updated system api image with the newer version. This version integrates the builder. Updated nuvolaris-wsku-roles to add required permissions.

This patch will complete the https://github.com/apache/openserverless/issues/156.

To use this new version, you need to:
- run a `ops setup kubernetes prepare` to update permissions
- run a `ops setup nuvolaris system-api update`
