### PR TITLE
util to expose miniops to the local network

### DIFF
--- a/util/docopts.md
+++ b/util/docopts.md
@@ -42,6 +42,7 @@ Usage:
   util ingress-type
   util edit [<plugin>]
   util link-plugin <plugin>
+  util docker-proxy [<port>] [<host>] [--remove]
 ```
 
 ## Commands
@@ -65,6 +66,7 @@ Usage:
 -  ingress-type            return the ingress type
 -  edit                    edit (with vscode) the current tasks or a plugin
 -  link-plugin             link the <plugin> in current directory to the global list
+-  docker-proxy            launch (or remove) in docker a proxy listening in public <port> (default 8080) to the <host> (default devel.miniops.me)
 ```
 
 ## Options

--- a/util/opsfile.yml
+++ b/util/opsfile.yml
@@ -256,3 +256,31 @@ tasks:
           echo "$PLUGIN not found"
           exit 1
         fi
+
+  docker-proxy:
+    desc: create in docker a proxy to expose miniops.me (or others)
+    silent: true
+    vars:
+      PORT: '{{or ._port_ "8080"}}'
+      HOST: '{{or ._host_ "devel.miniops.me"}}'
+      NGINX_CONF: >
+        server {
+           listen 80;
+           location / { 
+             proxy_pass http://nuvolaris-control-plane:80;
+             proxy_set_header Host {{.HOST}}; 
+           } 
+        }
+    cmds:
+    - |
+      if {{.__remove}}
+      then docker rm docker-proxy-{{.PORT}} -f
+      else
+        if docker run -d --name docker-proxy-{{.PORT}} -p {{.PORT}}:80 --network kind nginx:alpine sh -c \
+           "echo '{{.NGINX_CONF}}' > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+        then echo "docker-proxy started on port {{.PORT}} to  http://{{.HOST}}"
+        else echo "Cannot start docker-proxy-{{.PORT}} - either the port is busy or another instance is running, remove it" 
+        fi       
+      fi
+
+


### PR DESCRIPTION
if you want someone access to your machine to one namespace in your machine you can do it adding a proxy and doing `ops util docker-proxy`. By default you access to devel.miniops.me with http://<ip>:8080 - you will have to proxy other hostnames with other ports...