### PR TITLE
[FEATURE] Add support for seaweedfs in config tasks

### DIFF
--- a/config/docopts.md
+++ b/config/docopts.md
@@ -24,12 +24,12 @@ Configure OpenServerless
 
 ```text
 Usage:
-  config (enable|disable) [--all] [--redis] [--mongodb] [--minio] [--cron] [--static] [--postgres] [--prometheus] [--slack] [--mail] [--affinity] [--tolerations] [--quota] [--milvus] [--registry]
+  config (enable|disable) [--all] [--redis] [--mongodb] [--minio] [--cron] [--static] [--postgres] [--prometheus] [--slack] [--mail] [--affinity] [--tolerations] [--quota] [--milvus] [--registry] [--seaweedfs]
   config apihost (<apihost>|auto) [--tls=<email>] [--protocol=<http/https>|auto]
   config runtimes [<runtimesjson>]  
   config slack [--apiurl=<slackapiurl>] [--channel=<slackchannel>]
   config mail  [--mailuser=<mailuser>] [--mailpwd=<mailpwd>] [--mailfrom=<mailfrom>] [--mailto=<mailto>]
-  config volumes [--couchdb=<couchdb>] [--kafka=<kafka>] [--pgvol=<postgres>] [--storage=<storage>] [--alerting=<alerting>] [--zookeeper=<zookeeper>] [--redisvol=<redis>] [--mongodbvol=<mongodb>] [--etcdvol=<etcd>] [--mvvol=<milvus>] [--mvzookvol=<milvuszook>] [--pulsarjournalvol=<pulsarjournal>] [--pulsarledgelvol=<pulsarledge>]  
+  config volumes [--couchdb=<couchdb>] [--kafka=<kafka>] [--pgvol=<postgres>] [--storage=<storage>] [--alerting=<alerting>] [--zookeeper=<zookeeper>] [--redisvol=<redis>] [--mongodbvol=<mongodb>] [--etcdvol=<etcd>] [--mvvol=<milvus>] [--mvzookvol=<milvuszook>] [--pulsarjournalvol=<pulsarjournal>] [--pulsarledgelvol=<pulsarledge>] [--seaweedfsvol=<seaweedfsvol>]  
   config controller [--javaopts=<javaopts>] [--loglevel=<loglevel>] [--replicas=<replicas>]
   config ingress [--class=<auto|nginx|traefik|public>]
   config invoker [--javaopts=<javaopts>] [--poolmemory=<poolmemory>] [--timeoutsrun=<timeoutsrun>] [--timeoutslogs=<timeoutslogs>] [--loglevel=<loglevel>] [--replicas=<replicas>]
@@ -46,7 +46,8 @@ Usage:
   config azcloud [--project=<project>] [--region=<region>] [--vm=<vm>] [--disk=<disk>] [--key=<key>] [--image=<image>]
   config aks [--project=<project>] [--name=<name>] [--region=<region>] [--count=<count>]  [--vm=<vm>] [--disk=<disk>] [--key=<key>]
   config externalregistry [--regurl=<regurl>] [--reguser=<reguser>] [--regpassword=<regpassword>]
-  config registry [--disk=<disk>] [--ingress] 
+  config registry [--disk=<disk>] [--ingress]
+  config seaweedfs [--s3] [--console]
   config (status|export|reset)
   config use [<n>] [--delete] [--rename=<rename>]
   config minimal
@@ -123,4 +124,5 @@ Usage:
   --milvus              select MILVUS vector database
   --registry            activate the support for a private image registry for custom actions (by default it will install one)
   --class               specify the ingress class. It can be auto, traefik, nginx. On microk8s it should be public.
+  --seaweedfs           activate the support of SEAWEEDFS as S3 api and buckets provider
 ```

--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -1198,7 +1198,7 @@ tasks:
     - |
       config OPERATOR_COMPONENT_MONGODB=true
     - |
-      config OPERATOR_COMPONENT_MINIO=true
+      config OPERATOR_COMPONENT_SEAWEEDFS=true
     - |
       config OPERATOR_COMPONENT_CRON=true  
     - |
@@ -1217,6 +1217,7 @@ tasks:
       config OPERATOR_COMPONENT_KAFKA=false  
       config OPERATOR_COMPONENT_REDIS=true
       config OPERATOR_COMPONENT_MONGODB=true
+      config OPERATOR_COMPONENT_MINIO=false
       config OPERATOR_COMPONENT_SEAWEEDFS=true
       config OPERATOR_COMPONENT_CRON=true
       config OPERATOR_COMPONENT_STATIC=true

--- a/config/opsfile.yml
+++ b/config/opsfile.yml
@@ -124,7 +124,12 @@ tasks:
         then 
           config OPERATOR_COMPONENT_REGISTRY=true
           config REGISTRY_CONFIG_SECRET_PUSH_PULL="$(random --str 12)"
-        fi                 
+        fi  
+      - | 
+        if {{.__seaweedfs}} || {{.__all}}
+        then 
+          config OPERATOR_COMPONENT_SEAWEEDFS=true          
+        fi                         
       - config CONFIGURED=true
       - task: status
 
@@ -204,7 +209,12 @@ tasks:
         if {{.__registry}} || {{.__all}}
         then 
           config OPERATOR_CONFIG_REGISTRY=false
-        fi                                  
+        fi
+      - | 
+        if {{.__seaweedfs}} || {{.__all}}
+        then 
+          config OPERATOR_COMPONENT_SEAWEEDFS=false
+        fi                                            
       - task: status
 
   status:
@@ -870,7 +880,16 @@ tasks:
         HINT: | 
               Specifies an integer value
         VAL: "{{.__pulsarledgelvol}}"
-        DEF: "20"                                               
+        DEF: "20" 
+    - task: read
+      vars:
+        MSG: "SEAWEEDFS Volume size"
+        VAR: "STORAGE_SIZE_SEAWEEDFS"
+        HINT: | 
+              Specifies an integer value
+        VAL: "{{.__seaweedfsvol}}"
+        DEF: "60"         
+
 
   controller:
     silent: true
@@ -1158,6 +1177,18 @@ tasks:
           VAL: "{{.__disk}}"
           DEF: "50"
 
+  seaweefs:
+    silent: true
+    cmds:
+    - |
+      if {{.__s3}}
+      then config SEAWEEDFS_CONFIG_INGRESS_S3_ENABLED=true
+      fi    
+    - |
+      if {{.__console}}
+      then config SEAWEEDFS_CONFIG_INGRESS_CONSOLE_ENABLED=true
+      fi           
+
   minimal:
     silent: true
     cmds:
@@ -1186,13 +1217,13 @@ tasks:
       config OPERATOR_COMPONENT_KAFKA=false  
       config OPERATOR_COMPONENT_REDIS=true
       config OPERATOR_COMPONENT_MONGODB=true
-      config OPERATOR_COMPONENT_MINIO=true
+      config OPERATOR_COMPONENT_SEAWEEDFS=true
       config OPERATOR_COMPONENT_CRON=true
       config OPERATOR_COMPONENT_STATIC=true
       config OPERATOR_COMPONENT_POSTGRES=true
       config OPERATOR_COMPONENT_ETCD=true
       config OPERATOR_COMPONENT_MILVUS=true      
-      config MINIO_CONFIG_INGRESS_S3=true
+      config SEAWEEDFS_CONFIG_INGRESS_S3_ENABLED=true
       config ETCD_CONFIG_REPLICAS=1
       config POSTGRES_CONFIG_REPLICAS=1
       config OPERATOR_CONFIG_SLIM=true

--- a/opsroot.json
+++ b/opsroot.json
@@ -5,7 +5,7 @@
 	     "coreutils": "arch b2sum b3sum base32 basename basenc cat chgrp chmod chown chroot cksum comm cp csplit cut date dd df dir dircolors dirname du env expand expr factor fmt fold groups hashsum head hostid hostname id install join kill link ln logname ls md5sum mkdir mkfifo mknod mktemp more mv nice nl nohup nproc numfmt od paste pathchk pinky pr printenv printf ptx pwd readlink realpath rm rmdir seq sha1sum sha224sum sha256sum sha3-224sum sha3-256sum sha3-384sum sha3-512sum sha384sum sha3sum sha512sum shake128sum shake256sum shred shuf sleep sort split stat stdbuf stty sum sync tac tail tee timeout touch tr truncate tsort tty uname unexpand uniq unlink uptime users vdir wc who whoami yes"
        },
        "images": {
-         "operator": "registry.hub.docker.com/apache/openserverless-operator:0.1.0-incubating.2507271249",
+         "operator": "registry.hub.docker.com/apache/openserverless-operator:0.1.0-incubating.2509241822",
          "controller": "ghcr.io/nuvolaris/openwhisk-controller:3.1.0-mastrogpt.2402101445",
          "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445",
          "streamer": "registry.hub.docker.com/apache/openserverless-streamer:0.1.0-incubating.2505031325",

--- a/setup/kubernetes/crds/whisk-crd.yaml
+++ b/setup/kubernetes/crds/whisk-crd.yaml
@@ -149,7 +149,10 @@ spec:
                       type: boolean
                     registry:
                       description: deploys a private registry to load on the fly generated action runtimes (false by default)
-                      type: boolean                                              
+                      type: boolean
+                    seaweedfs:
+                      description: deploys an S3 compatible layer using a standalone deployment of seaweedfs
+                      type: boolean                                                                     
                   required:
                     - openwhisk
                     - couchdb
@@ -835,7 +838,50 @@ spec:
                   - mode
                   - volume-size
                   - auth
-                  - hostname                                         
+                  - hostname
+                seaweedfs:
+                  description: used to configure the internal saweedfs data storage service
+                  type: object
+                  properties:
+                    volume-size:
+                      description: volume size in GB, default to 60GB
+                      type: integer
+                    default-bucket-quota:
+                      description: default bucket quota, default to 1024MB
+                      type: integer
+                    nuvolaris:
+                      description: used to configure the MINIO nuvolaris user used for non administrative purposes
+                      type: object
+                      properties:
+                        user:
+                          type: string
+                        password:
+                          type: string
+                      required:
+                      - user
+                      - password
+                    ingress:
+                      description: configuration option for global minio ingresses exposure
+                      type: object
+                      properties:
+                        s3-enabled:
+                          description: boolean flag to activate SEAWEEDFS S3 compatible ingress. Default to false
+                          type: boolean
+                        s3-hostname:
+                          description: ingress hostname to be used if true (normally s3.<apihost>)
+                          type: string
+                        console-enabled:
+                          description: boolean flag to expose SEAWEEDFS Filer UI
+                          type: boolean
+                        console-hostname:
+                          description: ingress hostname to be used (nora=mally filer.<apihost>)
+                          type: string
+                      required:
+                      - s3-enabled
+                      - console-enabled                           
+                  required:
+                  - volume-size
+                  - nuvolaris                                                           
             status:
               x-kubernetes-preserve-unknown-fields: true
               # type: object
@@ -948,4 +994,9 @@ spec:
           type: string
           priority: 0
           jsonPath: .status.whisk_create.registry
-          description: Registry                                                                                                              
+          description: Registry 
+        - name: Seaweedfs
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_create.seaweedfs
+          description: Seaweedfs                                                                                                                        

--- a/setup/kubernetes/opsfile.yml
+++ b/setup/kubernetes/opsfile.yml
@@ -325,6 +325,18 @@ tasks:
             sh: echo "$OPERATOR_COMPONENT_MINIO"
       - task: wait-pod
         vars:
+          SELECTOR: "-l app=seaweedfs"
+          COND: 
+            sh: echo "$OPERATOR_COMPONENT_SEAWEEDFS"
+          FILE: _seaweedfs
+      - task: wait
+        vars:
+          OBJECT:
+            sh: echo "pod/$(cat _seaweedfs)"
+          COND: 
+            sh: echo "$OPERATOR_COMPONENT_SEAWEEDFS"            
+      - task: wait-pod
+        vars:
           SELECTOR: "-l name=nuvolaris-milvus"
           COND: 
             sh: echo "$OPERATOR_COMPONENT_MILVUS"

--- a/setup/kubernetes/whisk.yaml
+++ b/setup/kubernetes/whisk.yaml
@@ -69,6 +69,8 @@ spec:
     milvus: ${OPERATOR_COMPONENT_MILVUS:-false}
     # REGISTRY enabled or not
     registry: ${OPERATOR_COMPONENT_REGISTRY:-false}
+    # REGISTRY enabled or not
+    seaweedfs: ${OPERATOR_COMPONENT_SEAWEEDFS:-false}    
   tls:
     acme-registered-email: ${OPERATOR_CONFIG_TLSEMAIL:-no-reply@email.com}
     acme-server-url: https://acme-v02.api.letsencrypt.org/directory
@@ -251,4 +253,14 @@ spec:
       password: $REGISTRY_CONFIG_SECRET_PUSH_PULL
     hostname: ${REGISTRY_CONFIG_HOSTNAME:-auto}
     ingress:
-      enabled: ${REGISTRY_CONFIG_INGRESS_ENABLED:-false}       
+      enabled: ${REGISTRY_CONFIG_INGRESS_ENABLED:-false}
+  seaweedfs:
+    volume-size:  ${STORAGE_SIZE_SEAWEEDFS:-60}
+    nuvolaris:
+      user: nuvolaris
+      password: $SECRET_SEAWEEDFS_NUVOLARIS
+    ingress:
+      s3-enabled: ${SEAWEEDFS_CONFIG_INGRESS_S3_ENABLED:-true}
+      s3-hostname: ${SEAWEEDFS_CONFIG_INGRESS_S3_HOSTNAME:-auto}
+      console-enabled: ${SEAWEEDFS_CONFIG_INGRESS_CONSOLE_ENABLED:-false}
+      console-hostname: ${SEAWEEDFS_CONFIG_INGRESS_CONSOLE_HOSTNAME:-auto}              

--- a/util/opsfile.yml
+++ b/util/opsfile.yml
@@ -92,6 +92,7 @@ tasks:
       - config SECRET_POSTGRES_ADMIN="$(random --str 12)" SECRET_POSTGRES_REPLICA="$(random --str 12)" SECRET_POSTGRES_NUVOLARIS="$(random --str 12)"
       - config SECRET_ETCD_ROOT="$(random --str 12)" SECRET_MILVUS_ROOT="$(random --str 12)" SECRET_MILVUS_S3="$(random --str 12)" SECRET_MILVUS_NUVOLARIS="$(random --str 12)"
       - config SECRET_NUVOLARIS_METADATA="$(random --str 12)"
+      - config SECRET_SEAWEEDFS_NUVOLARIS="$(random --str 12)"
       - echo "Generated $(config -d | rg SECRET_ | wc -l) secrets."
 
   user-secrets:


### PR DESCRIPTION
This PR contributes: 

- Config task to setup seaweedfs
- Enable seaweedfs as default S3 API provider in the slim setup, by replacing MINIO.