### PR TITLE
fix: wait for system API readiness

### DIFF
--- a/setup/nuvolaris/system-api/api-template.yaml
+++ b/setup/nuvolaris/system-api/api-template.yaml
@@ -41,6 +41,14 @@ spec:
           ports:
             - containerPort: 5000
               name: api
+          readinessProbe:
+            tcpSocket:
+              port: api
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
           env:
           - name: "APIHOST"
             value: "${SYS_API_HOSTNAME:-localhost}"


### PR DESCRIPTION
## Summary
- add a TCP readiness probe to the Nuvolaris system API StatefulSet
- keep the Service endpoint unavailable until the admin API listener accepts connections
- make `kubectl rollout status` reflect application readiness before SSO login attempts

## Validation
- rendered manifest accepted by `kubectl apply --dry-run=client`
- live rollout in the Lima Kind cluster completed with the probe
- `openserverless-testing/tests/11-sso-mock.sh kind` completed with exit code 0