### PR TITLE
Update system API image for 0.9.1

### DIFF
--- a/opsroot.json
+++ b/opsroot.json
@@ -9,7 +9,7 @@
       "controller": "ghcr.io/nuvolaris/openwhisk-controller:3.1.0-mastrogpt.2402101445",
       "invoker": "ghcr.io/nuvolaris/openwhisk-invoker:3.1.0-mastrogpt.2402101445",
       "streamer": "docker.io/apache/openserverless-streamer:0.1.0-incubating.2505031325",
-      "systemapi": "docker.io/apache/openserverless-admin-api:0.9.1-incubating.2607101525",
+      "systemapi": "docker.io/apache/openserverless-admin-api:0.9.1-incubating.2607111849",
       "devcontainer": "apache/openserverless-devcontainer:0.1.0-incubating.2603111653",
       "ingress": "registry.k8s.io/ingress-nginx/controller:v1.7.0",
       "couchdb": "docker.io/apache/couchdb:2.3",


### PR DESCRIPTION
## Summary

Update the `systemapi` image in `opsroot.json` to the latest Apache OpenServerless Admin API build:

`docker.io/apache/openserverless-admin-api:0.9.1-incubating.2607111849`

## Why

This image was built from the merged admin-api PR #32 and contains the system API runtime dependencies preinstalled in the container image. This avoids downloading Python dependencies when the pod starts.

## Validation

- `jq empty opsroot.json`
- verified the configured JSON value
- `git diff --check`
- verified the Docker Hub OCI index and its `linux/amd64` and `linux/arm64` manifests
- source build: https://github.com/apache/openserverless-admin-api/actions/runs/29160496771