### PR TITLE
Preserve explicit workspace in IDE device login

### DIFF
--- a/ide/docopts.md
+++ b/ide/docopts.md
@@ -68,4 +68,5 @@ Usage:
 --fast          Skip the initial deployment step and go in incremental update mode
 --pin           Pin the current auth in the .env to check you are not deploying on the wrong user
 --mode          this will load from .env.<mode> after .env
+<username>      Optional workspace binding; omit it for SSO device flow to use the authenticated identity
 ```

--- a/ide/opsfile.yml
+++ b/ide/opsfile.yml
@@ -146,7 +146,7 @@ tasks:
         then export OPSDEV_APIHOST="{{._apihost_}}"
         fi
         echo "*** Configuring Access to OpenServerless ***"
-        if test "$SSO_ENABLED" = "true" && test "$OPS_SSO_LOGIN_FLOW" != "password"
+        if test "$SSO_ENABLED" = "true" && test "$OPS_SSO_LOGIN_FLOW" != "password" && test -z "{{._username_}}"
         then
             OPSDEV_USERNAME=""
         elif test -z "{{._username_}}"
@@ -188,7 +188,11 @@ tasks:
         else unset OPS_USER
         fi
         export OPS_APIHOST="$OPSDEV_APIHOST"
-        if $OPS -login
+        LOGIN_ARGS=()
+        if test -n "$OPSDEV_USERNAME"
+        then LOGIN_ARGS=("$OPSDEV_USERNAME")
+        fi
+        if $OPS -login "${LOGIN_ARGS[@]}"
         then
           source ~/.wskprops
           if test -z "$OPSDEV_USERNAME"
@@ -386,4 +390,3 @@ tasks:
 
   nodejs:
     desc: nodejs subcommand
-


### PR DESCRIPTION
## Summary

- keep ops ide login namespace-free for backend-managed SSO device flow when no username is supplied
- preserve and forward an explicit ops ide login <username> workspace to the CLI
- document that omitting <username> lets the authenticated identity determine the namespace

## Root cause

The device-flow branch cleared OPSDEV_USERNAME before checking the positional <username>. This prevented stale persisted state from being forwarded, but it also discarded a workspace explicitly supplied by the user. In addition, the nested CLI process reloads persisted config, so environment-only clearing cannot reliably express whether a workspace was intentional.

The task now invokes the CLI with no positional user for implicit device login and with the positional user when one was explicitly selected. The companion CLI fix gives this argument precedence over persisted environment values.

Companion PR: https://github.com/apache/openserverless-cli/pull/42

## Validation

- task --taskfile ide/opsfile.yml --list
- isolated task invocation with stale OPS_USER=nuvolaris and OPSDEV_USERNAME=nuvolaris: captured CLI arguments are only -login
- isolated ops ide login michelem: captured CLI arguments are -login michelem
- git diff --check

The admin-api authenticated-namespace mismatch check is not changed or bypassed.